### PR TITLE
Update dataset_json.py

### DIFF
--- a/cci_tagger_json/dataset_json.py
+++ b/cci_tagger_json/dataset_json.py
@@ -204,11 +204,9 @@ class DatasetJSONMappings:
         # If there are filters, these override dataset level realisations
         if filters:
 
-            filename = os.path.basename(filepath)
-
             # Check file against all filters
             for filter in filters:
-                m = re.match(filter['pattern'],filename)
+                m = re.match(filter['pattern'],str(filepath))
 
                 if m:
                     ds_real = filter.get('realisation')


### PR DESCRIPTION
Make it so that the realisation filters match against the whole path instead of just the filename.
Need to `str(filepath)` because file paths are Pathlib objects and cannot be matched with regex without changing the type.